### PR TITLE
Change source baseline to be Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <release>8</release>
+                    <source>8</source>
+                    <target>8</target>
+                    <testRelease>17</testRelease>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/microhttp/ByteTokenizer.java
+++ b/src/main/java/org/microhttp/ByteTokenizer.java
@@ -60,7 +60,7 @@ class ByteTokenizer {
 
     private int indexOf(byte[] delimiter) {
         for (int i = position; i <= size - delimiter.length; i++) {
-            if (Arrays.equals(delimiter, 0, delimiter.length, array, i, i + delimiter.length)) {
+            if (Arrays.equals(delimiter, Arrays.copyOfRange(array, i, i + delimiter.length))) {
                 return i;
             }
         }

--- a/src/main/java/org/microhttp/Header.java
+++ b/src/main/java/org/microhttp/Header.java
@@ -1,4 +1,48 @@
 package org.microhttp;
 
-public record Header(String name, String value) {
+import java.util.Objects;
+
+public final class Header {
+
+    private final String name;
+    private final String value;
+
+    public Header(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        Header that = (Header) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return "Header[" +
+                "name=" + name + ", " +
+                "value=" + value + ']';
+    }
+
 }

--- a/src/main/java/org/microhttp/LogEntry.java
+++ b/src/main/java/org/microhttp/LogEntry.java
@@ -1,4 +1,48 @@
 package org.microhttp;
 
-public record LogEntry(String key, String value) {
+import java.util.Objects;
+
+public final class LogEntry {
+
+    private final String key;
+    private final String value;
+
+    public LogEntry(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        LogEntry that = (LogEntry) obj;
+        return Objects.equals(this.key, that.key) &&
+                Objects.equals(this.value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return "LogEntry[" +
+                "key=" + key + ", " +
+                "value=" + value + ']';
+    }
+
 }

--- a/src/main/java/org/microhttp/Request.java
+++ b/src/main/java/org/microhttp/Request.java
@@ -1,17 +1,32 @@
 package org.microhttp;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
  * HTTP request entity.
  */
-public record Request(
-        String method,
-        String uri,
-        String version,
-        List<Header> headers,
-        byte[] body) {
+public final class Request {
+
+    private final String method;
+    private final String uri;
+    private final String version;
+    private final List<Header> headers;
+    private final byte[] body;
+
+    public Request(
+            String method,
+            String uri,
+            String version,
+            List<Header> headers,
+            byte[] body) {
+        this.method = method;
+        this.uri = uri;
+        this.version = version;
+        this.headers = headers;
+        this.body = body;
+    }
 
     public Optional<String> header(String name) {
         return headers.stream()
@@ -25,6 +40,57 @@ public record Request(
                 .filter(h -> h.name().equalsIgnoreCase(name))
                 .map(Header::value)
                 .anyMatch(v -> v.equalsIgnoreCase(value));
+    }
+
+    public String method() {
+        return method;
+    }
+
+    public String uri() {
+        return uri;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    public List<Header> headers() {
+        return headers;
+    }
+
+    public byte[] body() {
+        return body;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        Request that = (Request) obj;
+        return Objects.equals(this.method, that.method) &&
+                Objects.equals(this.uri, that.uri) &&
+                Objects.equals(this.version, that.version) &&
+                Objects.equals(this.headers, that.headers) &&
+                Objects.equals(this.body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, uri, version, headers, body);
+    }
+
+    @Override
+    public String toString() {
+        return "Request[" +
+                "method=" + method + ", " +
+                "uri=" + uri + ", " +
+                "version=" + version + ", " +
+                "headers=" + headers + ", " +
+                "body=" + body + ']';
     }
 
 }

--- a/src/main/java/org/microhttp/RequestParser.java
+++ b/src/main/java/org/microhttp/RequestParser.java
@@ -90,7 +90,7 @@ class RequestParser {
                 throw new IllegalStateException("multiple message lengths");
             }
             OptionalInt contentLength = findContentLength();
-            if (contentLength.isEmpty()) {
+            if (!contentLength.isPresent()) {
                 if (hasChunkedEncodingHeader()) {
                     state = State.CHUNK_SIZE;
                 } else {

--- a/src/main/java/org/microhttp/Response.java
+++ b/src/main/java/org/microhttp/Response.java
@@ -1,13 +1,27 @@
 package org.microhttp;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
-public record Response(
-        int status,
-        String reason,
-        List<Header> headers,
-        byte[] body) {
+public final class Response {
+
+    private final int status;
+    private final String reason;
+    private final List<Header> headers;
+    private final byte[] body;
+
+    public Response(
+            int status,
+            String reason,
+            List<Header> headers,
+            byte[] body) {
+        this.status = status;
+        this.reason = reason;
+        this.headers = headers;
+        this.body = body;
+    }
 
     public boolean hasHeader(String name) {
         return headers.stream().anyMatch(h -> h.name().equalsIgnoreCase(name));
@@ -25,7 +39,7 @@ public record Response(
         segments.add(SPACE);
         segments.add(reason.getBytes());
         segments.add(CRLF);
-        for (List<Header> list : List.of(headers, this.headers)) {
+        for (List<Header> list : Arrays.asList(headers, this.headers)) {
             for (Header header : list) {
                 segments.add(header.name().getBytes());
                 segments.add(COLON_SPACE);
@@ -47,6 +61,51 @@ public record Response(
             offset += segment.length;
         }
         return result;
+    }
+
+    public int status() {
+        return status;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    public List<Header> headers() {
+        return headers;
+    }
+
+    public byte[] body() {
+        return body;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        Response that = (Response) obj;
+        return this.status == that.status &&
+                Objects.equals(this.reason, that.reason) &&
+                Objects.equals(this.headers, that.headers) &&
+                Objects.equals(this.body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, reason, headers, body);
+    }
+
+    @Override
+    public String toString() {
+        return "Response[" +
+                "status=" + status + ", " +
+                "reason=" + reason + ", " +
+                "headers=" + headers + ", " +
+                "body=" + body + ']';
     }
 
 }


### PR DESCRIPTION
Change the source baseline to be Java 8. 

The IntelliJ support for using different source versions in source and test is still not available in their latest 2021.3 release. However, there is an open issue [IDEA-85478](https://youtrack.jetbrains.com/issue/IDEA-85478), which seems to have gained some traction and there is something working in the 2022.1 EAP (I tested it and it works good).

Almost all changes are due changing the convenience of the usage. However, the change in the `ByteTokenizer` might affect the performance, a multi release jar could be used here to in order to not lose any performance on Java 9+.