### PR TITLE
Add basic GitHub Actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn verify -B


### PR DESCRIPTION
This PR adds a rudimentary CI build based on [GitHub Actions](https://github.com/features/actions) to the project. You can find an [example run](https://github.com/beatngu13/microhttp/actions/runs/1855007521) in my fork.