### PR TITLE
Add simple concurrency to Microhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Principles:
 * No dependencies
 * Small, targeted codebase (~500 LOC)
 * Highly concurrent
-* Single threaded
+* Single-threaded event loops
 * Event-driven non-blocking NIO
 * No TLS support
 * No streaming support
@@ -58,8 +58,7 @@ and artifact `microhttp`.
 The snippet below represents a minimal starting point.
 Default options and debug logging.
 
-The application consists of an event loop running in the main thread.
-There are no additional application threads.
+The application consists of an event loop running in a background thread.
 
 Responses are handled immediately in the `Handler.handle` method.
 
@@ -72,6 +71,7 @@ Response response = new Response(
 Handler handler = (req, callback) -> callback.accept(response);
 EventLoop eventLoop = new EventLoop(handler);
 eventLoop.start();
+eventLoop.join();
 ```
 
 ***
@@ -91,11 +91,13 @@ Options options = new Options()
         .withResolution(Duration.ofMillis(100))
         .withReadBufferSize(1_024 * 64)
         .withMaxRequestSize(1_024 * 1_024)
-        .withAcceptLength(0);
+        .withAcceptLength(0)
+        .withConcurrency(4);
 Logger logger = new DebugLogger();
 Handler handler = (req, callback) -> callback.accept(response);
 EventLoop eventLoop = new EventLoop(options, logger, handler);
 eventLoop.start();
+eventLoop.join();
 ```
 
 ***
@@ -115,226 +117,11 @@ ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExe
 Handler handler = (req, callback) -> executorService.schedule(() -> callback.accept(response), 1, TimeUnit.SECONDS);
 EventLoop eventLoop = new EventLoop(handler);
 eventLoop.start();
-```
-
-***
-
-This example demonstrates the use of a separate thread for the event loop.
-
-
-```java
-Response response = new Response(
-        200,
-        "OK",
-        List.of(new Header("Content-Type", "text/plain")),
-        "hello world\n".getBytes());
-ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-Handler handler = (req, callback) -> executorService.schedule(() -> callback.accept(response), 1, TimeUnit.SECONDS);
-EventLoop eventLoop = new EventLoop(handler);
-Thread thread = new Thread(eventLoop::start);
-thread.start();
-// ...
-eventLoop.stop();
-thread.join();
+eventLoop.join();
 ```
 
 # Benchmarks
 
-The experiments detailed below were conducted on a pair of EC2 instances in AWS, 
-one running the server and another running the client.
-
-* Region: `us-west-2`
-* Instance type: `c5.2xlarge` compute optimized instance 8 vCPU and 16 GB of memory
-* OS: Amazon Linux 2 with Linux Kernel 5.10, AMI `ami-00f7e5c52c0f43726`
-* OpenJDK 17.0.2 from https://jdk.java.net/17/
-
-In order to facilitate the rapid creation of 50,000 connections, the following `sysctl` kernel parameter changes
-were committed on both hosts prior to the start of the experiment:
-
-```
-sysctl net.ipv4.ip_local_port_range="2000 64000"
-sysctl net.ipv4.tcp_fin_timeout=30
-sysctl net.core.somaxconn=8192
-sysctl net.core.netdev_max_backlog=8000
-sysctl net.ipv4.tcp_max_syn_backlog=8192
-```
-
-## Throughput
-
-The goal of throughput benchmarks is to gauge the maximum request-per-second rate 
-that can be supported by Microhttp. These experiments are intended to surface the costs
-and limitations of Microhttp alone. They are not intended to provide a real world estimate
-of throughput in an integrated system with many components and dependencies.
-
-### Server
-
-[ThroughputServer.java](https://gist.github.com/ebarlas/d932bda5901c2907596cc53bd89c781a) was used for throughput tests.
-
-It simply returns "hello world" in a tiny, plain-text response to every request. Requests are handled in the context of
-the main application thread, directly within the `Handler.handle` method.  
-
-### Apache Bench
-
-The first throughput test was conducted with [Apache Bench](https://httpd.apache.org/docs/2.4/programs/ab.html).
-
-A throughput of 100,000 requests per second was easily reproducible.
-
-```text
-[ec2-user@ip-10-39-196-99 ~]$ ab -k -c 100 -n 1000000 http://10.39.196.164:8080/
-This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
-Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
-Licensed to The Apache Software Foundation, http://www.apache.org/
-
-Benchmarking 10.39.196.164 (be patient)
-Completed 100000 requests
-Completed 200000 requests
-Completed 300000 requests
-Completed 400000 requests
-Completed 500000 requests
-Completed 600000 requests
-Completed 700000 requests
-Completed 800000 requests
-Completed 900000 requests
-Completed 1000000 requests
-Finished 1000000 requests
-
-
-Server Software:        
-Server Hostname:        10.39.196.164
-Server Port:            8080
-
-Document Path:          /
-Document Length:        12 bytes
-
-Concurrency Level:      100
-Time taken for tests:   9.964 seconds
-Complete requests:      1000000
-Failed requests:        0
-Keep-Alive requests:    1000000
-Total transferred:      101000000 bytes
-HTML transferred:       12000000 bytes
-Requests per second:    100364.03 [#/sec] (mean)
-Time per request:       0.996 [ms] (mean)
-Time per request:       0.010 [ms] (mean, across all concurrent requests)
-Transfer rate:          9899.19 [Kbytes/sec] received
-
-Connection Times (ms)
-              min  mean[+/-sd] median   max
-Connect:        0    0   0.0      0       1
-Processing:     1    1   0.0      1       3
-Waiting:        0    1   0.0      1       3
-Total:          1    1   0.0      1       3
-
-Percentage of the requests served within a certain time (ms)
-  50%      1
-  66%      1
-  75%      1
-  80%      1
-  90%      1
-  95%      1
-  98%      1
-  99%      1
- 100%      3 (longest request)
-```
-
-### NIO Client
-
-A second throughput client, [Client.java](https://gist.github.com/ebarlas/41d31a0ba546b879681c7e7007d75107), 
-was implemented with Java NIO and tailored specifically for Microhttp throughput testing.
-
-Again, 100,000+ requests per second was readily available.
-
-```
-[ec2-user@ip-10-39-196-99 ~]$ ./jdk-17.0.2/bin/java -cp microhttp-0.1-SNAPSHOT.jar test.Client 10.39.196.164 8080 100 30000
-Args[host=10.39.196.164, port=8080, numConnections=100, duration=30000]
-barrier opened!
-duration: 30001 ms, messages: 3250567, throughput: 108348.621713 msg/sec
-```
-
-## Concurrency
-
-The goal of concurrency benchmarks is to gauge the number of concurrent connections and clients
-that can be supported by Microhttp.
-
-### Server
-
-[ConcurrencyServer.java](https://gist.github.com/ebarlas/42aa8ce6ced6573b46a3e4e36d312535) was used for concurrency tests.
-
-"hello world" responses are handled in a separate background thread after an injected one-second delay. 
-The one-second delay dramatically reduces the resource footprint since requests and responses
-aren't speeding over each connection continuously. This leaves room to scale up connections, which is the metric of interest.
-
-### Apache Bench
-
-[Apache Bench](https://httpd.apache.org/docs/2.4/programs/ab.html) only supports a maximum of 20,000 concurrency connections.
-
-Microhttp holds up well. 
-
-```
-[ec2-user@ip-10-39-196-99 ~]$ ab -k -c 20000 -n 100000 http://10.39.196.164:8080/
-This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
-Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
-Licensed to The Apache Software Foundation, http://www.apache.org/
-
-Benchmarking 10.39.196.164 (be patient)
-Completed 10000 requests
-Completed 20000 requests
-Completed 30000 requests
-Completed 40000 requests
-Completed 50000 requests
-Completed 60000 requests
-Completed 70000 requests
-Completed 80000 requests
-Completed 90000 requests
-Completed 100000 requests
-Finished 100000 requests
-
-
-Server Software:        
-Server Hostname:        10.39.196.164
-Server Port:            8080
-
-Document Path:          /
-Document Length:        12 bytes
-
-Concurrency Level:      20000
-Time taken for tests:   6.825 seconds
-Complete requests:      100000
-Failed requests:        0
-Keep-Alive requests:    100000
-Total transferred:      10100000 bytes
-HTML transferred:       1200000 bytes
-Requests per second:    14652.72 [#/sec] (mean)
-Time per request:       1364.934 [ms] (mean)
-Time per request:       0.068 [ms] (mean, across all concurrent requests)
-Transfer rate:          1445.24 [Kbytes/sec] received
-
-Connection Times (ms)
-              min  mean[+/-sd] median   max
-Connect:        0   42  84.6      0     266
-Processing:  1000 1048  54.2   1013    1256
-Waiting:     1000 1048  54.2   1013    1174
-Total:       1000 1090 117.3   1022    1349
-
-Percentage of the requests served within a certain time (ms)
-  50%   1022
-  66%   1091
-  75%   1137
-  80%   1256
-  90%   1313
-  95%   1322
-  98%   1328
-  99%   1332
- 100%   1349 (longest request)
-```
-
-### NIO Client
-
-A concurrency level of 50,000 connections was achievable using [Client.java](https://gist.github.com/ebarlas/41d31a0ba546b879681c7e7007d75107).
-
-```
-[ec2-user@ip-10-39-196-99 ~]$ ./jdk-17.0.2/bin/java -cp microhttp-0.1-SNAPSHOT.jar test.Client 10.39.196.164 8080 50000 60000
-Args[host=10.39.196.164, port=8080, numConnections=50000, duration=60000]
-barrier opened!
-duration: 61001 ms, messages: 2968864, throughput: 48669.103785 msg/sec
-```
+The [benchmarks](benchmarks.md) doc outlines the concurrency and throughput
+scale achieved using a representative AWS cloud environment with separate
+EC2 instances for client and server applications.

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,0 +1,200 @@
+# Benchmarks
+
+The experiments detailed below were conducted on a pair of EC2 instances in AWS,
+one running the server and another running the client.
+
+* Region: `us-west-2`
+* Instance type: `c5.2xlarge` compute optimized instance 8 vCPU and 16 GB of memory
+* OS: Amazon Linux 2 with Linux Kernel 5.10, AMI `ami-00f7e5c52c0f43726`
+* OpenJDK 17.0.2 from https://jdk.java.net/17/
+
+In order to facilitate the rapid creation of 50,000 connections, the following `sysctl` kernel parameter changes
+were committed on both hosts prior to the start of the experiment:
+
+```
+sysctl net.ipv4.ip_local_port_range="2000 64000"
+sysctl net.ipv4.tcp_fin_timeout=30
+sysctl net.core.somaxconn=8192
+sysctl net.core.netdev_max_backlog=8000
+sysctl net.ipv4.tcp_max_syn_backlog=8192
+```
+
+## Throughput
+
+The goal of throughput benchmarks is to gauge the maximum request-per-second rate
+that can be supported by Microhttp. These experiments are intended to surface the costs
+and limitations of Microhttp alone. They are not intended to provide a real world estimate
+of throughput in an integrated system with many components and dependencies.
+
+### Server
+
+[ThroughputServer.java](https://gist.github.com/ebarlas/d932bda5901c2907596cc53bd89c781a) was used for throughput tests.
+
+It simply returns "hello world" in a tiny, plain-text response to every request. Requests are handled in the context of
+the main application thread, directly within the `Handler.handle` method.
+
+### Apache Bench
+
+The first throughput test was conducted with [Apache Bench](https://httpd.apache.org/docs/2.4/programs/ab.html).
+
+A throughput of 100,000 requests per second was easily reproducible.
+
+```text
+[ec2-user@ip-10-39-196-99 ~]$ ab -k -c 100 -n 1000000 http://10.39.196.164:8080/
+This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
+Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
+Licensed to The Apache Software Foundation, http://www.apache.org/
+
+Benchmarking 10.39.196.164 (be patient)
+Completed 100000 requests
+Completed 200000 requests
+Completed 300000 requests
+Completed 400000 requests
+Completed 500000 requests
+Completed 600000 requests
+Completed 700000 requests
+Completed 800000 requests
+Completed 900000 requests
+Completed 1000000 requests
+Finished 1000000 requests
+
+
+Server Software:        
+Server Hostname:        10.39.196.164
+Server Port:            8080
+
+Document Path:          /
+Document Length:        12 bytes
+
+Concurrency Level:      100
+Time taken for tests:   9.964 seconds
+Complete requests:      1000000
+Failed requests:        0
+Keep-Alive requests:    1000000
+Total transferred:      101000000 bytes
+HTML transferred:       12000000 bytes
+Requests per second:    100364.03 [#/sec] (mean)
+Time per request:       0.996 [ms] (mean)
+Time per request:       0.010 [ms] (mean, across all concurrent requests)
+Transfer rate:          9899.19 [Kbytes/sec] received
+
+Connection Times (ms)
+              min  mean[+/-sd] median   max
+Connect:        0    0   0.0      0       1
+Processing:     1    1   0.0      1       3
+Waiting:        0    1   0.0      1       3
+Total:          1    1   0.0      1       3
+
+Percentage of the requests served within a certain time (ms)
+  50%      1
+  66%      1
+  75%      1
+  80%      1
+  90%      1
+  95%      1
+  98%      1
+  99%      1
+ 100%      3 (longest request)
+```
+
+### NIO Client
+
+A second throughput client, [Client.java](https://gist.github.com/ebarlas/41d31a0ba546b879681c7e7007d75107),
+was implemented with Java NIO and tailored specifically for Microhttp throughput testing.
+
+Again, 100,000+ requests per second was readily available.
+
+```
+[ec2-user@ip-10-39-196-99 ~]$ ./jdk-17.0.2/bin/java -cp microhttp-0.1-SNAPSHOT.jar test.Client 10.39.196.164 8080 100 30000
+Args[host=10.39.196.164, port=8080, numConnections=100, duration=30000]
+barrier opened!
+duration: 30001 ms, messages: 3250567, throughput: 108348.621713 msg/sec
+```
+
+## Concurrency
+
+The goal of concurrency benchmarks is to gauge the number of concurrent connections and clients
+that can be supported by Microhttp.
+
+### Server
+
+[ConcurrencyServer.java](https://gist.github.com/ebarlas/42aa8ce6ced6573b46a3e4e36d312535) was used for concurrency tests.
+
+"hello world" responses are handled in a separate background thread after an injected one-second delay.
+The one-second delay dramatically reduces the resource footprint since requests and responses
+aren't speeding over each connection continuously. This leaves room to scale up connections, which is the metric of interest.
+
+### Apache Bench
+
+[Apache Bench](https://httpd.apache.org/docs/2.4/programs/ab.html) only supports a maximum of 20,000 concurrency connections.
+
+Microhttp holds up well.
+
+```
+[ec2-user@ip-10-39-196-99 ~]$ ab -k -c 20000 -n 100000 http://10.39.196.164:8080/
+This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
+Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
+Licensed to The Apache Software Foundation, http://www.apache.org/
+
+Benchmarking 10.39.196.164 (be patient)
+Completed 10000 requests
+Completed 20000 requests
+Completed 30000 requests
+Completed 40000 requests
+Completed 50000 requests
+Completed 60000 requests
+Completed 70000 requests
+Completed 80000 requests
+Completed 90000 requests
+Completed 100000 requests
+Finished 100000 requests
+
+
+Server Software:        
+Server Hostname:        10.39.196.164
+Server Port:            8080
+
+Document Path:          /
+Document Length:        12 bytes
+
+Concurrency Level:      20000
+Time taken for tests:   6.825 seconds
+Complete requests:      100000
+Failed requests:        0
+Keep-Alive requests:    100000
+Total transferred:      10100000 bytes
+HTML transferred:       1200000 bytes
+Requests per second:    14652.72 [#/sec] (mean)
+Time per request:       1364.934 [ms] (mean)
+Time per request:       0.068 [ms] (mean, across all concurrent requests)
+Transfer rate:          1445.24 [Kbytes/sec] received
+
+Connection Times (ms)
+              min  mean[+/-sd] median   max
+Connect:        0   42  84.6      0     266
+Processing:  1000 1048  54.2   1013    1256
+Waiting:     1000 1048  54.2   1013    1174
+Total:       1000 1090 117.3   1022    1349
+
+Percentage of the requests served within a certain time (ms)
+  50%   1022
+  66%   1091
+  75%   1137
+  80%   1256
+  90%   1313
+  95%   1322
+  98%   1328
+  99%   1332
+ 100%   1349 (longest request)
+```
+
+### NIO Client
+
+A concurrency level of 50,000 connections was achievable using [Client.java](https://gist.github.com/ebarlas/41d31a0ba546b879681c7e7007d75107).
+
+```
+[ec2-user@ip-10-39-196-99 ~]$ ./jdk-17.0.2/bin/java -cp microhttp-0.1-SNAPSHOT.jar test.Client 10.39.196.164 8080 50000 60000
+Args[host=10.39.196.164, port=8080, numConnections=50000, duration=60000]
+barrier opened!
+duration: 61001 ms, messages: 2968864, throughput: 48669.103785 msg/sec
+```

--- a/src/main/java/org/microhttp/ConnectionEventLoop.java
+++ b/src/main/java/org/microhttp/ConnectionEventLoop.java
@@ -1,0 +1,356 @@
+package org.microhttp;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This class represents an independent, threaded event loop for managed a group of connections.
+ * It has its own selector, byte buffer, and state-per-connection.
+ * <p>
+ * The diagram below outlines the various connection states.
+ *
+ * <pre>
+ *                                                   Write Complete Non-Persistent
+ *                                   Write     +--------------------------------------------+
+ *                                   Complete  |                                            |
+ *              Read                 Request   |                Write                       |
+ *              Partial              Pipelined |                Partial                     |
+ *              +-----+                +-----+ |                +-----+                     |
+ *              |     |                |     | |                |     |    Write            |
+ *              |     v                |     v |                |     v    Complete         v
+ *            +-+--------+  Read-     ++-------+-+  Write-    +-+--------+ Non-       +----------+
+ *    Accept  |          |  Complete  |          |  Partial   |          | Persist.   |          |
+ * ---------->| READABLE +----------->| DISPATCH +----------->| WRITABLE +----------->|  CLOSED  |
+ *            |          |            |          |            |          |            |          |
+ *            +----+-----+            +----------+ Write      +-+---+----+            +----------+
+ *                 |                        ^      Complete     |   |
+ *                 |                        |      Request      |   |
+ *                 |                        |      Pipelined    |   |
+ *                 |                        +-------------------+   |
+ *                 |                                                |
+ *                 +------------------------------------------------+
+ *                               Write Complete Persistent
+ * </pre>
+ */
+class ConnectionEventLoop {
+
+    private final Options options;
+    private final Logger logger;
+    private final Handler handler;
+    private final AtomicLong connectionCounter;
+    private final AtomicBoolean stop;
+
+    private final Scheduler timeoutQueue;
+    private final Queue<Runnable> taskQueue;
+    private final ByteBuffer readBuffer;
+    private final Selector selector;
+    private final Thread thread;
+
+    ConnectionEventLoop(
+            Options options,
+            Logger logger,
+            Handler handler,
+            AtomicLong connectionCounter,
+            AtomicBoolean stop) throws IOException {
+        this.options = options;
+        this.logger = logger;
+        this.handler = handler;
+        this.connectionCounter = connectionCounter;
+        this.stop = stop;
+
+        timeoutQueue = new Scheduler();
+        taskQueue = new ConcurrentLinkedQueue<>();
+        readBuffer = ByteBuffer.allocateDirect(options.readBufferSize());
+        selector = Selector.open();
+        thread = new Thread(this::run, "connection-event-loop");
+    }
+
+    private class Connection {
+        static final String HTTP_1_0 = "HTTP/1.0";
+        static final String HTTP_1_1 = "HTTP/1.1";
+
+        static final String HEADER_CONNECTION = "Connection";
+        static final String HEADER_CONTENT_LENGTH = "Content-Length";
+
+        static final String KEEP_ALIVE = "Keep-Alive";
+
+        final SocketChannel socketChannel;
+        final SelectionKey selectionKey;
+        final ByteTokenizer byteTokenizer;
+        final String id;
+        RequestParser requestParser;
+        ByteBuffer writeBuffer;
+        Cancellable requestTimeoutTask;
+        boolean httpOneDotZero;
+        boolean keepAlive;
+
+        private Connection(SocketChannel socketChannel, SelectionKey selectionKey) {
+            this.socketChannel = socketChannel;
+            this.selectionKey = selectionKey;
+            byteTokenizer = new ByteTokenizer();
+            id = Long.toString(connectionCounter.getAndIncrement());
+            requestParser = new RequestParser(byteTokenizer);
+            requestTimeoutTask = timeoutQueue.schedule(this::onRequestTimeout, options.requestTimeout());
+        }
+
+        private void onRequestTimeout() {
+            if (logger.enabled()) {
+                logger.log(
+                        new LogEntry("event", "request_timeout"),
+                        new LogEntry("id", id));
+            }
+            failSafeClose();
+        }
+
+        private void onReadable() {
+            try {
+                doOnReadable();
+            } catch (IOException | RuntimeException e) {
+                if (logger.enabled()) {
+                    logger.log(e,
+                            new LogEntry("event", "read_error"),
+                            new LogEntry("id", id));
+                }
+                failSafeClose();
+            }
+        }
+
+        private void doOnReadable() throws IOException {
+            readBuffer.clear();
+            int numBytes = socketChannel.read(readBuffer);
+            if (numBytes < 0) {
+                if (logger.enabled()) {
+                    logger.log(
+                            new LogEntry("event", "read_close"),
+                            new LogEntry("id", id));
+                }
+                failSafeClose();
+                return;
+            }
+            readBuffer.flip();
+            byteTokenizer.add(readBuffer);
+            if (logger.enabled()) {
+                logger.log(
+                        new LogEntry("event", "read_bytes"),
+                        new LogEntry("id", id),
+                        new LogEntry("read_bytes", Integer.toString(numBytes)),
+                        new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
+            }
+            if (requestParser.parse()) {
+                if (logger.enabled()) {
+                    logger.log(
+                            new LogEntry("event", "read_request"),
+                            new LogEntry("id", id),
+                            new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
+                }
+                onParseRequest();
+            } else {
+                if (byteTokenizer.size() > options.maxRequestSize()) {
+                    if (logger.enabled()) {
+                        logger.log(
+                                new LogEntry("event", "exceed_request_max_close"),
+                                new LogEntry("id", id),
+                                new LogEntry("request_size", Integer.toString(byteTokenizer.size())));
+                    }
+                    failSafeClose();
+                }
+            }
+        }
+
+        private void onParseRequest() {
+            if (selectionKey.interestOps() != 0) {
+                selectionKey.interestOps(0);
+            }
+            if (requestTimeoutTask != null) {
+                requestTimeoutTask.cancel();
+                requestTimeoutTask = null;
+            }
+            Request request = requestParser.request();
+            httpOneDotZero = request.version().equalsIgnoreCase(HTTP_1_0);
+            keepAlive = request.hasHeader(HEADER_CONNECTION, KEEP_ALIVE);
+            byteTokenizer.compact();
+            requestParser = new RequestParser(byteTokenizer);
+            handler.handle(request, this::onResponse);
+        }
+
+        private void onResponse(Response response) {
+            // enqueuing the callback invocation and waking the selector
+            // ensures that the response callback works properly when
+            // invoked inline from the event loop thread or a separate background thread
+            taskQueue.add(() -> {
+                try {
+                    prepareToWriteResponse(response);
+                } catch (IOException e) {
+                    if (logger.enabled()) {
+                        logger.log(e,
+                                new LogEntry("event", "response_ready_error"),
+                                new LogEntry("id", id));
+                    }
+                    failSafeClose();
+                }
+            });
+            // selector wakeup is not necessary if callback was invoked within event loop thread
+            // since scheduler tasks are processed at the end of every event loop iteration
+            if (Thread.currentThread() != thread) {
+                selector.wakeup();
+            }
+        }
+
+        private void prepareToWriteResponse(Response response) throws IOException {
+            String version = httpOneDotZero ? HTTP_1_0 : HTTP_1_1;
+            List<Header> headers = new ArrayList<>();
+            if (httpOneDotZero && keepAlive) {
+                headers.add(new Header(HEADER_CONNECTION, KEEP_ALIVE));
+            }
+            if (!response.hasHeader(HEADER_CONTENT_LENGTH)) {
+                headers.add(new Header(HEADER_CONTENT_LENGTH, Integer.toString(response.body().length)));
+            }
+            writeBuffer = ByteBuffer.wrap(response.serialize(version, headers));
+            if (logger.enabled()) {
+                logger.log(
+                        new LogEntry("event", "response_ready"),
+                        new LogEntry("id", id),
+                        new LogEntry("num_bytes", Integer.toString(writeBuffer.remaining())));
+            }
+            doOnWritable();
+        }
+
+        private void onWritable() {
+            try {
+                doOnWritable();
+            } catch (IOException | RuntimeException e) {
+                if (logger.enabled()) {
+                    logger.log(e,
+                            new LogEntry("event", "write_error"),
+                            new LogEntry("id", id));
+                }
+                failSafeClose();
+            }
+        }
+
+        private void doOnWritable() throws IOException {
+            int numBytes = socketChannel.write(writeBuffer);
+            if (!writeBuffer.hasRemaining()) { // response fully written
+                writeBuffer = null; // done with current write buffer, remove reference
+                if (logger.enabled()) {
+                    logger.log(
+                            new LogEntry("event", "write_response"),
+                            new LogEntry("id", id),
+                            new LogEntry("num_bytes", Integer.toString(numBytes)));
+                }
+                if (httpOneDotZero && !keepAlive) { // non-persistent connection, close now
+                    if (logger.enabled()) {
+                        logger.log(
+                                new LogEntry("event", "close_after_response"),
+                                new LogEntry("id", id));
+                    }
+                    failSafeClose();
+                } else { // persistent connection
+                    if (requestParser.parse()) { // subsequent request in buffer
+                        if (logger.enabled()) {
+                            logger.log(
+                                    new LogEntry("event", "pipeline_request"),
+                                    new LogEntry("id", id),
+                                    new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
+                        }
+                        onParseRequest();
+                    } else { // switch back to read mode
+                        requestTimeoutTask = timeoutQueue.schedule(this::onRequestTimeout, options.requestTimeout());
+                        selectionKey.interestOps(SelectionKey.OP_READ);
+                    }
+                }
+            } else { // response not fully written, switch to or remain in write mode
+                if ((selectionKey.interestOps() & SelectionKey.OP_WRITE) == 0) {
+                    selectionKey.interestOps(SelectionKey.OP_WRITE);
+                }
+                if (logger.enabled()) {
+                    logger.log(
+                            new LogEntry("event", "write"),
+                            new LogEntry("id", id),
+                            new LogEntry("num_bytes", Integer.toString(numBytes)));
+                }
+            }
+        }
+
+        private void failSafeClose() {
+            try {
+                if (requestTimeoutTask != null) {
+                    requestTimeoutTask.cancel();
+                }
+                selectionKey.cancel();
+                socketChannel.close();
+            } catch (IOException e) {
+                // suppress error
+            }
+        }
+    }
+
+    int numConnections() {
+        return selector.keys().size();
+    }
+
+    void start() {
+        thread.start();
+    }
+
+    void join() throws InterruptedException {
+        thread.join();
+    }
+
+    private void run() {
+        try {
+            doStart();
+        } catch (IOException e) {
+            if (logger.enabled()) {
+                logger.log(e, new LogEntry("event", "sub_event_loop_terminate"));
+            }
+            stop.set(true); // stop the world on critical error
+        }
+    }
+
+    private void doStart() throws IOException {
+        while (!stop.get()) {
+            selector.select(options.resolution().toMillis());
+            Set<SelectionKey> selectedKeys = selector.selectedKeys();
+            Iterator<SelectionKey> it = selectedKeys.iterator();
+            while (it.hasNext()) {
+                SelectionKey selKey = it.next();
+                if (selKey.isReadable()) {
+                    ((Connection) selKey.attachment()).onReadable();
+                } else if (selKey.isWritable()) {
+                    ((Connection) selKey.attachment()).onWritable();
+                }
+                it.remove();
+            }
+            timeoutQueue.expired().forEach(Runnable::run);
+            Runnable task;
+            while ((task = taskQueue.poll()) != null) {
+                task.run();
+            }
+        }
+    }
+
+    void register(SocketChannel socketChannel) throws IOException {
+        socketChannel.configureBlocking(false);
+        SelectionKey selectionKey = socketChannel.register(selector, SelectionKey.OP_READ);
+        Connection connection = new Connection(socketChannel, selectionKey);
+        selectionKey.attach(connection);
+        if (logger.enabled()) {
+            logger.log(
+                    new LogEntry("event", "accept"),
+                    new LogEntry("remote_address", socketChannel.getRemoteAddress().toString()),
+                    new LogEntry("id", connection.id));
+        }
+    }
+}

--- a/src/main/java/org/microhttp/EventLoop.java
+++ b/src/main/java/org/microhttp/EventLoop.java
@@ -3,63 +3,31 @@ package org.microhttp;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.StandardSocketOptions;
-import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
-import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * EventLoop is an HTTP server implementation. It provides connection management, network I/O,
  * request parsing, and request dispatching.
- * <p>
- * The diagram below outlines the various connection states.
- *
- * <pre>
- *                                                   Write Complete Non-Persistent
- *                                   Write     +--------------------------------------------+
- *                                   Complete  |                                            |
- *              Read                 Request   |                Write                       |
- *              Partial              Pipelined |                Partial                     |
- *              +-----+                +-----+ |                +-----+                     |
- *              |     |                |     | |                |     |    Write            |
- *              |     v                |     v |                |     v    Complete         v
- *            +-+--------+  Read-     ++-------+-+  Write-    +-+--------+ Non-       +----------+
- *    Accept  |          |  Complete  |          |  Partial   |          | Persist.   |          |
- * ---------->| READABLE +----------->| DISPATCH +----------->| WRITABLE +----------->|  CLOSED  |
- *            |          |            |          |            |          |            |          |
- *            +----+-----+            +----------+ Write      +-+---+----+            +----------+
- *                 |                        ^      Complete     |   |
- *                 |                        |      Request      |   |
- *                 |                        |      Pipelined    |   |
- *                 |                        +-------------------+   |
- *                 |                                                |
- *                 +------------------------------------------------+
- *                               Write Complete Persistent
- * </pre>
  */
 public class EventLoop {
 
     private final Options options;
     private final Logger logger;
-    private final Handler handler;
 
-    private final Scheduler timeoutQueue;
-    private final Queue<Runnable> taskQueue;
-    private final ByteBuffer readBuffer;
     private final Selector selector;
+    private final AtomicBoolean stop;
     private final ServerSocketChannel serverSocketChannel;
-
-    private long connectionCounter;
-
-    private Thread eventLoopThread;
-    private volatile boolean stop;
+    private final List<ConnectionEventLoop> connectionEventLoops;
+    private final Thread thread;
 
     public EventLoop(Handler handler) throws IOException {
         this(new Options(), handler);
@@ -72,12 +40,17 @@ public class EventLoop {
     public EventLoop(Options options, Logger logger, Handler handler) throws IOException {
         this.options = options;
         this.logger = logger;
-        this.handler = handler;
 
-        timeoutQueue = new Scheduler();
-        taskQueue = new ConcurrentLinkedQueue<>();
-        readBuffer = ByteBuffer.allocateDirect(options.readBufferSize());
         selector = Selector.open();
+        stop = new AtomicBoolean();
+
+        AtomicLong connectionCounter = new AtomicLong();
+        connectionEventLoops = new ArrayList<>();
+        for (int i = 0; i < options.concurrency(); i++) {
+            connectionEventLoops.add(new ConnectionEventLoop(options, logger, handler, connectionCounter, stop));
+        }
+
+        thread = new Thread(this::run, "event-loop");
 
         InetSocketAddress address = options.host() == null
                 ? new InetSocketAddress(options.port()) // wildcard address
@@ -99,276 +72,52 @@ public class EventLoop {
         return serverSocketChannel.getLocalAddress() instanceof InetSocketAddress a ? a.getPort() : -1;
     }
 
-    private class Connection {
-        static final String HTTP_1_0 = "HTTP/1.0";
-        static final String HTTP_1_1 = "HTTP/1.1";
-
-        static final String HEADER_CONNECTION = "Connection";
-        static final String HEADER_CONTENT_LENGTH = "Content-Length";
-
-        static final String KEEP_ALIVE = "Keep-Alive";
-
-        final SocketChannel socketChannel;
-        final SelectionKey selectionKey;
-        final ByteTokenizer byteTokenizer;
-        final String id;
-        RequestParser requestParser;
-        ByteBuffer writeBuffer;
-        Cancellable requestTimeoutTask;
-        boolean httpOneDotZero;
-        boolean keepAlive;
-
-        private Connection(SocketChannel socketChannel, SelectionKey selectionKey) {
-            this.socketChannel = socketChannel;
-            this.selectionKey = selectionKey;
-            byteTokenizer = new ByteTokenizer();
-            id = Long.toString(connectionCounter++);
-            requestParser = new RequestParser(byteTokenizer);
-            requestTimeoutTask = timeoutQueue.schedule(this::onRequestTimeout, options.requestTimeout());
-        }
-
-        private void onRequestTimeout() {
-            if (logger.enabled()) {
-                logger.log(
-                        new LogEntry("event", "request_timeout"),
-                        new LogEntry("id", id));
-            }
-            failSafeClose();
-        }
-
-        private void onReadable() {
-            try {
-                doOnReadable();
-            } catch (IOException | RuntimeException e) {
-                if (logger.enabled()) {
-                    logger.log(e,
-                            new LogEntry("event", "read_error"),
-                            new LogEntry("id", id));
-                }
-                failSafeClose();
-            }
-        }
-
-        private void doOnReadable() throws IOException {
-            readBuffer.clear();
-            int numBytes = socketChannel.read(readBuffer);
-            if (numBytes < 0) {
-                if (logger.enabled()) {
-                    logger.log(
-                            new LogEntry("event", "read_close"),
-                            new LogEntry("id", id));
-                }
-                failSafeClose();
-                return;
-            }
-            readBuffer.flip();
-            byteTokenizer.add(readBuffer);
-            if (logger.enabled()) {
-                logger.log(
-                        new LogEntry("event", "read_bytes"),
-                        new LogEntry("id", id),
-                        new LogEntry("read_bytes", Integer.toString(numBytes)),
-                        new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
-            }
-            if (requestParser.parse()) {
-                if (logger.enabled()) {
-                    logger.log(
-                            new LogEntry("event", "read_request"),
-                            new LogEntry("id", id),
-                            new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
-                }
-                onParseRequest();
-            } else {
-                if (byteTokenizer.size() > options.maxRequestSize()) {
-                    if (logger.enabled()) {
-                        logger.log(
-                                new LogEntry("event", "exceed_request_max_close"),
-                                new LogEntry("id", id),
-                                new LogEntry("request_size", Integer.toString(byteTokenizer.size())));
-                    }
-                    failSafeClose();
-                }
-            }
-        }
-
-        private void onParseRequest() {
-            if (selectionKey.interestOps() != 0) {
-                selectionKey.interestOps(0);
-            }
-            if (requestTimeoutTask != null) {
-                requestTimeoutTask.cancel();
-                requestTimeoutTask = null;
-            }
-            Request request = requestParser.request();
-            httpOneDotZero = request.version().equalsIgnoreCase(HTTP_1_0);
-            keepAlive = request.hasHeader(HEADER_CONNECTION, KEEP_ALIVE);
-            byteTokenizer.compact();
-            requestParser = new RequestParser(byteTokenizer);
-            handler.handle(request, this::onResponse);
-        }
-
-        private void onResponse(Response response) {
-            // enqueuing the callback invocation and waking the selector
-            // ensures that the response callback works properly when
-            // invoked inline from the event loop thread or a separate background thread
-            taskQueue.add(() -> {
-                try {
-                    prepareToWriteResponse(response);
-                } catch (IOException e) {
-                    if (logger.enabled()) {
-                        logger.log(e,
-                                new LogEntry("event", "response_ready_error"),
-                                new LogEntry("id", id));
-                    }
-                    failSafeClose();
-                }
-            });
-            // selector wakeup is not necessary if callback was invoked within event loop thread
-            // since scheduler tasks are processed at the end of every event loop iteration
-            if (Thread.currentThread() != eventLoopThread) {
-                selector.wakeup();
-            }
-        }
-
-        private void prepareToWriteResponse(Response response) throws IOException {
-            String version = httpOneDotZero ? HTTP_1_0 : HTTP_1_1;
-            List<Header> headers = new ArrayList<>();
-            if (httpOneDotZero && keepAlive) {
-                headers.add(new Header(HEADER_CONNECTION, KEEP_ALIVE));
-            }
-            if (!response.hasHeader(HEADER_CONTENT_LENGTH)) {
-                headers.add(new Header(HEADER_CONTENT_LENGTH, Integer.toString(response.body().length)));
-            }
-            writeBuffer = ByteBuffer.wrap(response.serialize(version, headers));
-            if (logger.enabled()) {
-                logger.log(
-                        new LogEntry("event", "response_ready"),
-                        new LogEntry("id", id),
-                        new LogEntry("num_bytes", Integer.toString(writeBuffer.remaining())));
-            }
-            doOnWritable();
-        }
-
-        private void onWritable() {
-            try {
-                doOnWritable();
-            } catch (IOException | RuntimeException e) {
-                if (logger.enabled()) {
-                    logger.log(e,
-                            new LogEntry("event", "write_error"),
-                            new LogEntry("id", id));
-                }
-                failSafeClose();
-            }
-        }
-
-        private void doOnWritable() throws IOException {
-            int numBytes = socketChannel.write(writeBuffer);
-            if (!writeBuffer.hasRemaining()) { // response fully written
-                writeBuffer = null; // done with current write buffer, remove reference
-                if (logger.enabled()) {
-                    logger.log(
-                            new LogEntry("event", "write_response"),
-                            new LogEntry("id", id),
-                            new LogEntry("num_bytes", Integer.toString(numBytes)));
-                }
-                if (httpOneDotZero && !keepAlive) { // non-persistent connection, close now
-                    if (logger.enabled()) {
-                        logger.log(
-                                new LogEntry("event", "close_after_response"),
-                                new LogEntry("id", id));
-                    }
-                    failSafeClose();
-                } else { // persistent connection
-                    if (requestParser.parse()) { // subsequent request in buffer
-                        if (logger.enabled()) {
-                            logger.log(
-                                    new LogEntry("event", "pipeline_request"),
-                                    new LogEntry("id", id),
-                                    new LogEntry("request_bytes", Integer.toString(byteTokenizer.remaining())));
-                        }
-                        onParseRequest();
-                    } else { // switch back to read mode
-                        requestTimeoutTask = timeoutQueue.schedule(this::onRequestTimeout, options.requestTimeout());
-                        selectionKey.interestOps(SelectionKey.OP_READ);
-                    }
-                }
-            } else { // response not fully written, switch to or remain in write mode
-                if ((selectionKey.interestOps() & SelectionKey.OP_WRITE) == 0) {
-                    selectionKey.interestOps(SelectionKey.OP_WRITE);
-                }
-                if (logger.enabled()) {
-                    logger.log(
-                            new LogEntry("event", "write"),
-                            new LogEntry("id", id),
-                            new LogEntry("num_bytes", Integer.toString(numBytes)));
-                }
-            }
-        }
-
-        private void failSafeClose() {
-            try {
-                if (requestTimeoutTask != null) {
-                    requestTimeoutTask.cancel();
-                }
-                selectionKey.cancel();
-                socketChannel.close();
-            } catch (IOException e) {
-                // suppress error
-            }
-        }
+    public void start() {
+        thread.start();
+        connectionEventLoops.forEach(ConnectionEventLoop::start);
     }
 
-    public void start() {
+    private void run() {
         try {
-            doStart();
+            doRun();
         } catch (IOException e) {
             if (logger.enabled()) {
-                logger.log(e, new LogEntry("event", "terminate"));
+                logger.log(e, new LogEntry("event", "event_loop_terminate"));
             }
+            stop.set(true); // stop the world on critical error
         }
     }
 
-    public void doStart() throws IOException {
-        eventLoopThread = Thread.currentThread();
-        while (!stop) {
+    private void doRun() throws IOException {
+        while (!stop.get()) {
             selector.select(options.resolution().toMillis());
             Set<SelectionKey> selectedKeys = selector.selectedKeys();
             Iterator<SelectionKey> it = selectedKeys.iterator();
             while (it.hasNext()) {
                 SelectionKey selKey = it.next();
                 if (selKey.isAcceptable()) {
-                    onAcceptable();
-                } else if (selKey.isReadable()) {
-                    ((Connection) selKey.attachment()).onReadable();
-                } else if (selKey.isWritable()) {
-                    ((Connection) selKey.attachment()).onWritable();
+                    ConnectionEventLoop connectionEventLoop = leastConnections();
+                    connectionEventLoop.register(serverSocketChannel.accept());
                 }
                 it.remove();
-            }
-            timeoutQueue.expired().forEach(Runnable::run);
-            Runnable task;
-            while ((task = taskQueue.poll()) != null) {
-                task.run();
             }
         }
     }
 
-    public void stop() {
-        stop = true;
+    private ConnectionEventLoop leastConnections() {
+        return connectionEventLoops.stream()
+                .min(Comparator.comparing(ConnectionEventLoop::numConnections))
+                .get();
     }
 
-    private void onAcceptable() throws IOException {
-        SocketChannel socketChannel = serverSocketChannel.accept();
-        socketChannel.configureBlocking(false);
-        SelectionKey selectionKey = socketChannel.register(selector, SelectionKey.OP_READ);
-        Connection connection = new Connection(socketChannel, selectionKey);
-        selectionKey.attach(connection);
-        if (logger.enabled()) {
-            logger.log(
-                    new LogEntry("event", "accept"),
-                    new LogEntry("remote_address", socketChannel.getRemoteAddress().toString()),
-                    new LogEntry("id", connection.id));
+    public void stop() {
+        stop.set(true);
+    }
+
+    public void join() throws InterruptedException {
+        thread.join();
+        for (ConnectionEventLoop connectionEventLoop : connectionEventLoops) {
+            connectionEventLoop.join();
         }
     }
 }

--- a/src/main/java/org/microhttp/Options.java
+++ b/src/main/java/org/microhttp/Options.java
@@ -13,6 +13,7 @@ public class Options {
     private int readBufferSize = 1_024 * 64;
     private int acceptLength = 0;
     private int maxRequestSize = 1_024 * 1_024;
+    private int concurrency = Runtime.getRuntime().availableProcessors();
 
     public String host() {
         return host;
@@ -48,6 +49,10 @@ public class Options {
 
     public int maxRequestSize() {
         return maxRequestSize;
+    }
+
+    public int concurrency() {
+        return concurrency;
     }
 
     public Options withHost(String host) {
@@ -92,6 +97,11 @@ public class Options {
 
     public Options withMaxRequestSize(int maxRequestSize) {
         this.maxRequestSize = maxRequestSize;
+        return this;
+    }
+
+    public Options withConcurrency(int concurrency) {
+        this.concurrency = concurrency;
         return this;
     }
 }

--- a/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
+++ b/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
@@ -27,7 +27,6 @@ public class EventLoopConcurrencyTest {
     static ExecutorService executor;
     static int port;
     static EventLoop eventLoop;
-    static Thread eventLoopThread;
 
     @BeforeAll
     static void beforeAll() throws IOException {
@@ -46,15 +45,14 @@ public class EventLoopConcurrencyTest {
             callback.accept(response);
         });
         eventLoop = new EventLoop(options, new DisabledLogger(), handler);
+        eventLoop.start();
         port = eventLoop.getPort();
-        eventLoopThread = new Thread(eventLoop::start);
-        eventLoopThread.start();
     }
 
     @AfterAll
     static void afterAll() throws InterruptedException {
         eventLoop.stop();
-        eventLoopThread.join();
+        eventLoop.join();
         executor.shutdown();
     }
 

--- a/src/test/java/org/microhttp/EventLoopTest.java
+++ b/src/test/java/org/microhttp/EventLoopTest.java
@@ -30,7 +30,6 @@ public class EventLoopTest {
     static ExecutorService executor;
     static int port;
     static EventLoop eventLoop;
-    static Thread eventLoopThread;
 
     static final String HTTP10_REQUEST = """
             GET /file HTTP/1.0\r
@@ -94,15 +93,14 @@ public class EventLoopTest {
                         "OK",
                         List.of(new Header("Content-Type", "text/plain")),
                         responseBody.getBytes()))));
+        eventLoop.start();
         port = eventLoop.getPort();
-        eventLoopThread = new Thread(eventLoop::start);
-        eventLoopThread.start();
     }
 
     @AfterAll
     static void afterAll() throws InterruptedException {
         eventLoop.stop();
-        eventLoopThread.join();
+        eventLoop.join();
         executor.shutdown();
     }
 


### PR DESCRIPTION
Split event loop into (1) single passive-server-socket event loop and (2) many active-socket events loops.

Each event loop is single-threaded and independent. Still no locking or synchronization. 

This design is facilitated by `Selector`, which permits select on one thread and register on another.