### PR TITLE
Add a no-op Logger

### DIFF
--- a/src/main/java/org/microhttp/Logger.java
+++ b/src/main/java/org/microhttp/Logger.java
@@ -2,6 +2,8 @@ package org.microhttp;
 
 /**
  * Simple logging abstraction that operates on {@link LogEntry} instances.
+ *
+ * @see NoopLogger for using a logger that is not enabled
  */
 public interface Logger {
 
@@ -19,9 +21,5 @@ public interface Logger {
      * Creates a new log event consisting of an exception and multiple log entries.
      */
     void log(Exception e, LogEntry... entries);
-
-    static Logger noop() {
-        return NoopLogger.INSTANCE;
-    }
 
 }

--- a/src/main/java/org/microhttp/Logger.java
+++ b/src/main/java/org/microhttp/Logger.java
@@ -20,4 +20,8 @@ public interface Logger {
      */
     void log(Exception e, LogEntry... entries);
 
+    static Logger noop() {
+        return NoopLogger.INSTANCE;
+    }
+
 }

--- a/src/main/java/org/microhttp/NoopLogger.java
+++ b/src/main/java/org/microhttp/NoopLogger.java
@@ -1,8 +1,11 @@
 package org.microhttp;
 
-final class NoopLogger implements Logger {
+/**
+ * A logger that is disabled and does not log anything.
+ */
+public final class NoopLogger implements Logger {
 
-    static final NoopLogger INSTANCE = new NoopLogger();
+    private static final NoopLogger INSTANCE = new NoopLogger();
 
     private NoopLogger() {
     }
@@ -21,4 +24,9 @@ final class NoopLogger implements Logger {
     public void log(Exception e, LogEntry... entries) {
 
     }
+
+    public static Logger instance() {
+        return INSTANCE;
+    }
+
 }

--- a/src/main/java/org/microhttp/NoopLogger.java
+++ b/src/main/java/org/microhttp/NoopLogger.java
@@ -1,0 +1,24 @@
+package org.microhttp;
+
+final class NoopLogger implements Logger {
+
+    static final NoopLogger INSTANCE = new NoopLogger();
+
+    private NoopLogger() {
+    }
+
+    @Override
+    public boolean enabled() {
+        return false;
+    }
+
+    @Override
+    public void log(LogEntry... entries) {
+
+    }
+
+    @Override
+    public void log(Exception e, LogEntry... entries) {
+
+    }
+}

--- a/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
+++ b/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
@@ -45,7 +45,7 @@ public class EventLoopConcurrencyTest {
                     req.body());
             callback.accept(response);
         });
-        eventLoop = new EventLoop(options, new DisabledLogger(), handler);
+        eventLoop = new EventLoop(options, NoopLogger.instance(), handler);
         eventLoop.start();
         port = eventLoop.getPort();
     }
@@ -91,23 +91,6 @@ public class EventLoopConcurrencyTest {
                 Arguments.arguments(1, 10),
                 Arguments.arguments(10, 100),
                 Arguments.arguments(100, 1_000));
-    }
-
-    static class DisabledLogger implements Logger {
-        @Override
-        public boolean enabled() {
-            return false;
-        }
-
-        @Override
-        public void log(LogEntry... entries) {
-
-        }
-
-        @Override
-        public void log(Exception e, LogEntry... entries) {
-
-        }
     }
 
 }

--- a/src/test/java/org/microhttp/LoggerTest.java
+++ b/src/test/java/org/microhttp/LoggerTest.java
@@ -9,8 +9,8 @@ public class LoggerTest {
 
     @Test
     public void noopLogger() {
-        Logger logger = Logger.noop();
+        Logger logger = NoopLogger.instance();
         assertFalse(logger.enabled());
-        assertSame(NoopLogger.INSTANCE, logger);
+        assertSame(NoopLogger.instance(), logger);
     }
 }

--- a/src/test/java/org/microhttp/LoggerTest.java
+++ b/src/test/java/org/microhttp/LoggerTest.java
@@ -1,0 +1,16 @@
+package org.microhttp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class LoggerTest {
+
+    @Test
+    public void noopLogger() {
+        Logger logger = Logger.noop();
+        assertFalse(logger.enabled());
+        assertSame(NoopLogger.INSTANCE, logger);
+    }
+}


### PR DESCRIPTION
We have recently moved to Java 17 and are starting to use Microhttp as a mock server (we need to validate our requests).

Having a no-op Logger makes it easier to disable the logging.