### PR TITLE
Expose a method for getting an OptionsBuilder on the Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Response response = new Response(
         "OK",
         List.of(new Header("Content-Type", "text/plain")),
         "hello world\n".getBytes());
-Options options = OptionsBuilder.newBuilder()
+Options options = Options.builder()
         .withHost("localhost")
         .withPort(8080)
         .withRequestTimeout(Duration.ofSeconds(60))

--- a/src/main/java/org/microhttp/EventLoop.java
+++ b/src/main/java/org/microhttp/EventLoop.java
@@ -30,7 +30,7 @@ public class EventLoop {
     private final Thread thread;
 
     public EventLoop(Handler handler) throws IOException {
-        this(OptionsBuilder.newBuilder().build(), handler);
+        this(Options.builder().build(), handler);
     }
 
     public EventLoop(Options options, Handler handler) throws IOException {

--- a/src/main/java/org/microhttp/Options.java
+++ b/src/main/java/org/microhttp/Options.java
@@ -5,4 +5,8 @@ import java.time.Duration;
 public record Options(String host, int port, boolean reuseAddr, boolean reusePort, Duration resolution,
                       Duration requestTimeout, int readBufferSize, int acceptLength, int maxRequestSize,
                       int concurrency) {
+
+    static OptionsBuilder builder() {
+        return OptionsBuilder.newBuilder();
+    }
 }

--- a/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
+++ b/src/test/java/org/microhttp/EventLoopConcurrencyTest.java
@@ -31,7 +31,7 @@ public class EventLoopConcurrencyTest {
     @BeforeAll
     public static void beforeAll() throws IOException {
         executor = Executors.newFixedThreadPool(1);
-        Options options = OptionsBuilder.newBuilder()
+        Options options = Options.builder()
                 .withPort(0)
                 .withRequestTimeout(Duration.ofMillis(2_500))
                 .withReadBufferSize(1_024)

--- a/src/test/java/org/microhttp/TestServer.java
+++ b/src/test/java/org/microhttp/TestServer.java
@@ -31,7 +31,7 @@ public class TestServer {
         Handler h = handleInline
                 ? (req, callback) -> c.accept(callback)
                 : (req, callback) -> executor.execute(() -> c.accept(callback));
-        Options options = OptionsBuilder.newBuilder()
+        Options options = Options.builder()
                 .withPort(0)
                 .withRequestTimeout(Duration.ofMillis(2_500))
                 .withReadBufferSize(readBufferSize)


### PR DESCRIPTION
This iterates on #17 by exposing the builder through `Options#builder()` it makes it a bit easier for discovery and less classes that should be imported when creating a `Options`