### PR TITLE
Print maven version and do not display maven download transfer progress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,4 +16,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn verify -B
+        run: mvn verify -B -V --no-transfer-progress


### PR DESCRIPTION
When using `-V` then the maven version information is printed:

```
Apache Maven 3.8.8 (4c87b05d9aedce574290d1acc98575ed5eb6cd39)
Maven home: /usr/share/apache-maven-3.8.8
Java version: 17.0.8, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-1041-azure", arch: "amd64", family: "unix"
```

and when using `--no-transfer-progress` then the build will not have things like:

```
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom (19 kB at 2.3 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom (1.0 kB at 204 kB/s)
```

It reduces the output of the "Build with Maven" step from 545 lines to 66, making it way more readable