### PR TITLE
fix get request null body

### DIFF
--- a/src/main/java/org/microhttp/RequestParser.java
+++ b/src/main/java/org/microhttp/RequestParser.java
@@ -95,6 +95,7 @@ class RequestParser {
                     state = State.CHUNK_SIZE;
                 } else {
                     state = State.DONE;
+                    this.contentLength = 0;
                 }
             } else {
                 this.contentLength = contentLength;


### PR DESCRIPTION
The issue lies in the logic of handling requests without a content-length header or chunked transfer encoding. If neither of these headers is present, the code sets the state to DONE, which results in a null value for the request body.

This modification ensures that if neither the content-length header nor the chunked encoding header is present, the request's state is set to DONE, and the content length is explicitly set to zero to indicate that there is no body content in the request. 